### PR TITLE
feat: Implement bookmarking feature (MVP)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,9 +34,18 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+    buildFeatures {
+        viewBinding = true
+    }
 }
 
 dependencies {
+    // Room for database
+    val roomVersion = "2.6.1"
+    implementation("androidx.room:room-runtime:$roomVersion")
+    kapt("androidx.room:room-compiler:$roomVersion")
+    implementation("androidx.room:room-ktx:$roomVersion")
+
     // Retrofit for networking
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".RosetteApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -23,6 +24,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".bookmarks.BookmarksActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
@@ -43,6 +43,13 @@ import com.bumptech.glide.Glide
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 
@@ -74,7 +81,9 @@ class MainActivity : AppCompatActivity() {
     private var isProgrammaticLoad = false
     private var pagesToLoad = 0
     private var pagesLoaded = 0
-    private var currentWikidataId: String? = null
+    private val currentWikidataId = MutableStateFlow<String?>(null)
+    private lateinit var isBookmarked: StateFlow<Boolean>
+    private var bookmarkMenuItem: MenuItem? = null
 
     private val wikipediaApiService = RetrofitClient.wikipediaApiService
     private val bookmarkDao by lazy {
@@ -158,6 +167,23 @@ class MainActivity : AppCompatActivity() {
 
         setupSuggestions()
 
+        isBookmarked = currentWikidataId.flatMapLatest { id ->
+            if (id == null) {
+                flowOf(false)
+            } else {
+                bookmarkDao.getBookmark(id).map { it != null }
+            }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+        lifecycleScope.launch {
+            isBookmarked.collect { bookmarked ->
+                bookmarkMenuItem?.let {
+                    val icon = if (bookmarked) R.drawable.ic_star else R.drawable.ic_star_outline
+                    it.setIcon(icon)
+                }
+            }
+        }
+
         if (savedInstanceState != null) {
             Log.d(TAG, "onCreate: Restoring instance state.")
             webViewMap.forEach { (key, webView) ->
@@ -216,6 +242,10 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menuInflater.inflate(R.menu.main_menu, menu)
+        bookmarkMenuItem = menu?.findItem(R.id.action_bookmark)
+        // Set initial icon state based on the current value
+        val icon = if (isBookmarked.value) R.drawable.ic_star else R.drawable.ic_star_outline
+        bookmarkMenuItem?.setIcon(icon)
         return true
     }
 
@@ -223,16 +253,24 @@ class MainActivity : AppCompatActivity() {
         return when (item.itemId) {
             R.id.action_bookmark -> {
                 Log.d(TAG, "Bookmark action clicked")
-                currentWikidataId?.let { id ->
+                val id = currentWikidataId.value
+                if (id != null) {
                     lifecycleScope.launch {
-                        val bookmark = io.github.nicolasraoul.rosette.data.db.Bookmark(
-                            wikidataId = id,
-                            timestamp = System.currentTimeMillis()
-                        )
-                        bookmarkDao.insert(bookmark)
-                        Toast.makeText(this@MainActivity, "Bookmark saved", Toast.LENGTH_SHORT).show()
+                        if (isBookmarked.value) {
+                            bookmarkDao.delete(id)
+                            Toast.makeText(this@MainActivity, "Bookmark removed", Toast.LENGTH_SHORT).show()
+                        } else {
+                            val bookmark = io.github.nicolasraoul.rosette.data.db.Bookmark(
+                                wikidataId = id,
+                                timestamp = System.currentTimeMillis()
+                            )
+                            bookmarkDao.insert(bookmark)
+                            Toast.makeText(this@MainActivity, "Bookmark saved", Toast.LENGTH_SHORT).show()
+                        }
                     }
-                } ?: Toast.makeText(this, "Cannot save bookmark: article not identified", Toast.LENGTH_SHORT).show()
+                } else {
+                    Toast.makeText(this, "Cannot save bookmark: article not identified", Toast.LENGTH_SHORT).show()
+                }
                 true
             }
             R.id.action_bookmarks -> {
@@ -549,7 +587,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun performFullSearch(searchTerm: String, sitelinks: Map<String, String>? = null, wikidataId: String? = null) {
         Log.d(TAG, "performFullSearch: Starting a new search for '$searchTerm'. Wikidata ID: $wikidataId")
-        this.currentWikidataId = wikidataId
+        this.currentWikidataId.value = wikidataId
         // TODO: Refactor the 'else' block below to fetch the wikidataId for plain searches to allow bookmarking.
 
         lifecycleScope.launch {
@@ -590,6 +628,7 @@ class MainActivity : AppCompatActivity() {
 
                 if (sourceLangFound == null || finalTitleFromSource == null) {
                     updateStatus("Article \"$searchTerm\" not found.")
+                    this@MainActivity.currentWikidataId.value = null
                     progressBarMap.values.forEach { it.visibility = View.GONE }
                     isProgrammaticLoad = false
                     return@launch

--- a/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
@@ -173,7 +173,7 @@ class MainActivity : AppCompatActivity() {
             } else {
                 bookmarkDao.getBookmark(id).map { it != null }
             }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+        }.stateIn(lifecycleScope, SharingStarted.WhileSubscribed(5000), false)
 
         lifecycleScope.launch {
             isBookmarked.collect { bookmarked ->

--- a/app/src/main/java/io/github/nicolasraoul/rosette/RosetteApplication.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/RosetteApplication.kt
@@ -1,0 +1,8 @@
+package io.github.nicolasraoul.rosette
+
+import android.app.Application
+import io.github.nicolasraoul.rosette.data.db.BookmarkDatabase
+
+class RosetteApplication : Application() {
+    val database: BookmarkDatabase by lazy { BookmarkDatabase.getDatabase(this) }
+}

--- a/app/src/main/java/io/github/nicolasraoul/rosette/WikipediaApiService.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/WikipediaApiService.kt
@@ -109,7 +109,13 @@ data class EntityClaimsResponse(
 data class EntityClaim(
     val id: String,
     val claims: Map<String, List<Claim>>?,
-    val sitelinks: Map<String, SiteLink>?
+    val sitelinks: Map<String, SiteLink>?,
+    val labels: Map<String, Label>?
+)
+
+data class Label(
+    val language: String,
+    val value: String
 )
 
 data class SiteLink(

--- a/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksActivity.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksActivity.kt
@@ -6,7 +6,10 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.snackbar.Snackbar
+import io.github.nicolasraoul.rosette.LanguageManager
 import io.github.nicolasraoul.rosette.RosetteApplication
 import io.github.nicolasraoul.rosette.databinding.ActivityBookmarksBinding
 import kotlinx.coroutines.flow.collectLatest
@@ -16,7 +19,10 @@ class BookmarksActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityBookmarksBinding
     private val viewModel: BookmarksViewModel by viewModels {
-        BookmarksViewModelFactory((application as RosetteApplication).database.bookmarkDao())
+        BookmarksViewModelFactory(
+            (application as RosetteApplication).database.bookmarkDao(),
+            LanguageManager(this)
+        )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -45,6 +51,22 @@ class BookmarksActivity : AppCompatActivity() {
                 bookmarksAdapter.submitList(bookmarks)
             }
         }
+
+        val itemTouchHelperCallback = object : ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
+            override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
+                return false
+            }
+
+            override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
+                val position = viewHolder.adapterPosition
+                val bookmark = bookmarksAdapter.currentList[position]
+                viewModel.delete(bookmark)
+                Snackbar.make(binding.root, "Bookmark deleted", Snackbar.LENGTH_LONG).show()
+            }
+        }
+
+        val itemTouchHelper = ItemTouchHelper(itemTouchHelperCallback)
+        itemTouchHelper.attachToRecyclerView(binding.bookmarksRecyclerView)
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksActivity.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksActivity.kt
@@ -1,0 +1,58 @@
+package io.github.nicolasraoul.rosette.bookmarks
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import io.github.nicolasraoul.rosette.RosetteApplication
+import io.github.nicolasraoul.rosette.databinding.ActivityBookmarksBinding
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+class BookmarksActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityBookmarksBinding
+    private val viewModel: BookmarksViewModel by viewModels {
+        BookmarksViewModelFactory((application as RosetteApplication).database.bookmarkDao())
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityBookmarksBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.toolbarBookmarks)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        title = "Bookmarks"
+
+        val bookmarksAdapter = BookmarksAdapter { bookmark ->
+            val resultIntent = Intent()
+            resultIntent.putExtra(EXTRA_WIKIDATA_ID, bookmark.wikidataId)
+            setResult(Activity.RESULT_OK, resultIntent)
+            finish()
+        }
+
+        binding.bookmarksRecyclerView.apply {
+            layoutManager = LinearLayoutManager(this@BookmarksActivity)
+            adapter = bookmarksAdapter
+        }
+
+        lifecycleScope.launch {
+            viewModel.bookmarks.collectLatest { bookmarks ->
+                bookmarksAdapter.submitList(bookmarks)
+            }
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
+    }
+
+    companion object {
+        const val EXTRA_WIKIDATA_ID = "io.github.nicolasraoul.rosette.WIKIDATA_ID"
+    }
+}

--- a/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksActivity.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksActivity.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
 import io.github.nicolasraoul.rosette.LanguageManager
 import io.github.nicolasraoul.rosette.RosetteApplication

--- a/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksActivity.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksActivity.kt
@@ -5,6 +5,9 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -30,6 +33,12 @@ class BookmarksActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityBookmarksBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.updatePadding(top = insets.top, bottom = insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         setSupportActionBar(binding.toolbarBookmarks)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)

--- a/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksAdapter.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksAdapter.kt
@@ -3,10 +3,12 @@ package io.github.nicolasraoul.rosette.bookmarks
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import io.github.nicolasraoul.rosette.R
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -14,7 +16,8 @@ import java.util.Locale
 
 data class BookmarkViewData(
     val wikidataId: String,
-    val title: String,
+    val imageUrl: String?,
+    val titles: Map<String, String>, // Map of lang code to title
     val timestamp: Long
 )
 
@@ -23,7 +26,10 @@ class BookmarksAdapter(private val onClick: (BookmarkViewData) -> Unit) :
 
     class BookmarkViewHolder(itemView: View, val onClick: (BookmarkViewData) -> Unit) :
         RecyclerView.ViewHolder(itemView) {
-        private val titleTextView: TextView = itemView.findViewById(R.id.bookmark_title)
+        private val imageView: ImageView = itemView.findViewById(R.id.bookmark_image)
+        private val titleTextView1: TextView = itemView.findViewById(R.id.bookmark_title1)
+        private val titleTextView2: TextView = itemView.findViewById(R.id.bookmark_title2)
+        private val titleTextView3: TextView = itemView.findViewById(R.id.bookmark_title3)
         private val timestampTextView: TextView = itemView.findViewById(R.id.bookmark_timestamp)
         private var currentBookmark: BookmarkViewData? = null
 
@@ -37,7 +43,28 @@ class BookmarksAdapter(private val onClick: (BookmarkViewData) -> Unit) :
 
         fun bind(bookmark: BookmarkViewData) {
             currentBookmark = bookmark
-            titleTextView.text = bookmark.title
+
+            if (bookmark.imageUrl != null) {
+                Glide.with(itemView.context)
+                    .load(bookmark.imageUrl)
+                    .centerCrop()
+                    .into(imageView)
+            } else {
+                imageView.setImageResource(R.drawable.ic_star)
+            }
+
+            val titles = bookmark.titles.values.toList()
+            val textViews = listOf(titleTextView1, titleTextView2, titleTextView3)
+            textViews.forEachIndexed { index, textView ->
+                val title = titles.getOrNull(index)
+                if (title != null) {
+                    textView.text = title
+                    textView.visibility = View.VISIBLE
+                } else {
+                    textView.visibility = View.GONE
+                }
+            }
+
             timestampTextView.text = "Saved on ${formatTimestamp(bookmark.timestamp)}"
         }
 

--- a/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksAdapter.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksAdapter.kt
@@ -1,0 +1,70 @@
+package io.github.nicolasraoul.rosette.bookmarks
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import io.github.nicolasraoul.rosette.R
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+data class BookmarkViewData(
+    val wikidataId: String,
+    val title: String,
+    val timestamp: Long
+)
+
+class BookmarksAdapter(private val onClick: (BookmarkViewData) -> Unit) :
+    ListAdapter<BookmarkViewData, BookmarksAdapter.BookmarkViewHolder>(BookmarkDiffCallback) {
+
+    class BookmarkViewHolder(itemView: View, val onClick: (BookmarkViewData) -> Unit) :
+        RecyclerView.ViewHolder(itemView) {
+        private val titleTextView: TextView = itemView.findViewById(R.id.bookmark_title)
+        private val timestampTextView: TextView = itemView.findViewById(R.id.bookmark_timestamp)
+        private var currentBookmark: BookmarkViewData? = null
+
+        init {
+            itemView.setOnClickListener {
+                currentBookmark?.let {
+                    onClick(it)
+                }
+            }
+        }
+
+        fun bind(bookmark: BookmarkViewData) {
+            currentBookmark = bookmark
+            titleTextView.text = bookmark.title
+            timestampTextView.text = "Saved on ${formatTimestamp(bookmark.timestamp)}"
+        }
+
+        private fun formatTimestamp(timestamp: Long): String {
+            val sdf = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
+            return sdf.format(Date(timestamp))
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BookmarkViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.bookmark_item, parent, false)
+        return BookmarkViewHolder(view, onClick)
+    }
+
+    override fun onBindViewHolder(holder: BookmarkViewHolder, position: Int) {
+        val bookmark = getItem(position)
+        holder.bind(bookmark)
+    }
+}
+
+object BookmarkDiffCallback : DiffUtil.ItemCallback<BookmarkViewData>() {
+    override fun areItemsTheSame(oldItem: BookmarkViewData, newItem: BookmarkViewData): Boolean {
+        return oldItem.wikidataId == newItem.wikidataId
+    }
+
+    override fun areContentsTheSame(oldItem: BookmarkViewData, newItem: BookmarkViewData): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksAdapter.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksAdapter.kt
@@ -11,7 +11,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import io.github.nicolasraoul.rosette.R
 import java.text.SimpleDateFormat
-import java.util.Date
 import java.util.Locale
 
 data class BookmarkViewData(
@@ -30,7 +29,6 @@ class BookmarksAdapter(private val onClick: (BookmarkViewData) -> Unit) :
         private val titleTextView1: TextView = itemView.findViewById(R.id.bookmark_title1)
         private val titleTextView2: TextView = itemView.findViewById(R.id.bookmark_title2)
         private val titleTextView3: TextView = itemView.findViewById(R.id.bookmark_title3)
-        private val timestampTextView: TextView = itemView.findViewById(R.id.bookmark_timestamp)
         private var currentBookmark: BookmarkViewData? = null
 
         init {
@@ -64,13 +62,6 @@ class BookmarksAdapter(private val onClick: (BookmarkViewData) -> Unit) :
                     textView.visibility = View.GONE
                 }
             }
-
-            timestampTextView.text = "Saved on ${formatTimestamp(bookmark.timestamp)}"
-        }
-
-        private fun formatTimestamp(timestamp: Long): String {
-            val sdf = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
-            return sdf.format(Date(timestamp))
         }
     }
 

--- a/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksViewModel.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksViewModel.kt
@@ -3,6 +3,7 @@ package io.github.nicolasraoul.rosette.bookmarks
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import io.github.nicolasraoul.rosette.LanguageManager
 import io.github.nicolasraoul.rosette.RetrofitClient
 import io.github.nicolasraoul.rosette.WikipediaApiService
 import io.github.nicolasraoul.rosette.data.db.BookmarkDao
@@ -10,52 +11,75 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 class BookmarksViewModel(
     bookmarkDao: BookmarkDao,
-    private val wikipediaApiService: WikipediaApiService
+    private val wikipediaApiService: WikipediaApiService,
+    private val languageManager: LanguageManager
 ) : ViewModel() {
 
     val bookmarks: StateFlow<List<BookmarkViewData>> = bookmarkDao.getAll()
         .map { bookmarks ->
             if (bookmarks.isEmpty()) {
-                return@map emptyList<BookmarkViewData>()
+                return@map emptyList()
             }
-            val ids = bookmarks.joinToString("|")
+            val ids = bookmarks.joinToString("|") { it.wikidataId }
             try {
-                val response = wikipediaApiService.getEntityClaims(ids = ids, props = "labels")
+                val response = wikipediaApiService.getEntityClaims(ids = ids, props = "sitelinks|claims")
                 if (response.isSuccessful) {
                     val entities = response.body()?.entities
+                    val displayLangs = languageManager.getDisplayLanguages()
+
                     bookmarks.map { bookmark ->
                         val entity = entities?.get(bookmark.wikidataId)
-                        val label = entity?.labels?.get("en")?.value // Default to English label
-                            ?: bookmark.wikidataId // Fallback to ID
+
+                        val imageName = (entity?.claims?.get("P18")?.firstOrNull()?.mainsnak?.datavalue?.value as? String)?.replace(" ", "_")
+                        val imageUrl = if (imageName != null) "https://commons.wikimedia.org/w/thumb.php?f=$imageName&w=200" else null
+
+                        val titles = mutableMapOf<String, String>()
+                        displayLangs.forEach { langCode ->
+                            val siteKey = "${langCode}wiki"
+                            val title = entity?.sitelinks?.get(siteKey)?.title
+                            if (title != null) {
+                                titles[langCode] = title
+                            }
+                        }
+                        if (titles.isEmpty()) {
+                            val fallbackTitle = entity?.sitelinks?.values?.firstOrNull()?.title ?: bookmark.wikidataId
+                            titles["fallback"] = fallbackTitle
+                        }
+
                         BookmarkViewData(
                             wikidataId = bookmark.wikidataId,
-                            title = label,
+                            imageUrl = imageUrl,
+                            titles = titles,
                             timestamp = bookmark.timestamp
                         )
                     }
                 } else {
-                    bookmarks.map {
-                        BookmarkViewData(it.wikidataId, "Could not load title", it.timestamp)
-                    }
+                    bookmarks.map { BookmarkViewData(it.wikidataId, null, mapOf("error" to "Could not load titles"), it.timestamp) }
                 }
             } catch (e: Exception) {
-                bookmarks.map {
-                    BookmarkViewData(it.wikidataId, "Error loading title", it.timestamp)
-                }
+                bookmarks.map { BookmarkViewData(it.wikidataId, null, mapOf("error" to "Error: ${e.message}"), it.timestamp) }
             }
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun delete(bookmark: BookmarkViewData) {
+        viewModelScope.launch {
+            bookmarkDao.delete(bookmark.wikidataId)
+        }
+    }
 }
 
 class BookmarksViewModelFactory(
-    private val bookmarkDao: BookmarkDao
+    private val bookmarkDao: BookmarkDao,
+    private val languageManager: LanguageManager
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(BookmarksViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return BookmarksViewModel(bookmarkDao, RetrofitClient.wikipediaApiService) as T
+            return BookmarksViewModel(bookmarkDao, RetrofitClient.wikipediaApiService, languageManager) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksViewModel.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksViewModel.kt
@@ -1,0 +1,62 @@
+package io.github.nicolasraoul.rosette.bookmarks
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import io.github.nicolasraoul.rosette.RetrofitClient
+import io.github.nicolasraoul.rosette.WikipediaApiService
+import io.github.nicolasraoul.rosette.data.db.BookmarkDao
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+class BookmarksViewModel(
+    bookmarkDao: BookmarkDao,
+    private val wikipediaApiService: WikipediaApiService
+) : ViewModel() {
+
+    val bookmarks: StateFlow<List<BookmarkViewData>> = bookmarkDao.getAll()
+        .map { bookmarks ->
+            if (bookmarks.isEmpty()) {
+                return@map emptyList<BookmarkViewData>()
+            }
+            val ids = bookmarks.joinToString("|")
+            try {
+                val response = wikipediaApiService.getEntityClaims(ids = ids, props = "labels")
+                if (response.isSuccessful) {
+                    val entities = response.body()?.entities
+                    bookmarks.map { bookmark ->
+                        val entity = entities?.get(bookmark.wikidataId)
+                        val label = entity?.labels?.get("en")?.value // Default to English label
+                            ?: bookmark.wikidataId // Fallback to ID
+                        BookmarkViewData(
+                            wikidataId = bookmark.wikidataId,
+                            title = label,
+                            timestamp = bookmark.timestamp
+                        )
+                    }
+                } else {
+                    bookmarks.map {
+                        BookmarkViewData(it.wikidataId, "Could not load title", it.timestamp)
+                    }
+                }
+            } catch (e: Exception) {
+                bookmarks.map {
+                    BookmarkViewData(it.wikidataId, "Error loading title", it.timestamp)
+                }
+            }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+}
+
+class BookmarksViewModelFactory(
+    private val bookmarkDao: BookmarkDao
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(BookmarksViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return BookmarksViewModel(bookmarkDao, RetrofitClient.wikipediaApiService) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksViewModel.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/bookmarks/BookmarksViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class BookmarksViewModel(
-    bookmarkDao: BookmarkDao,
+    private val bookmarkDao: BookmarkDao,
     private val wikipediaApiService: WikipediaApiService,
     private val languageManager: LanguageManager
 ) : ViewModel() {

--- a/app/src/main/java/io/github/nicolasraoul/rosette/data/db/Bookmark.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/data/db/Bookmark.kt
@@ -25,4 +25,7 @@ interface BookmarkDao {
 
     @Query("SELECT * FROM bookmarks ORDER BY timestamp DESC")
     fun getAll(): Flow<List<Bookmark>>
+
+    @Query("SELECT * FROM bookmarks WHERE wikidataId = :wikidataId")
+    fun getBookmark(wikidataId: String): Flow<Bookmark?>
 }

--- a/app/src/main/java/io/github/nicolasraoul/rosette/data/db/Bookmark.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/data/db/Bookmark.kt
@@ -1,0 +1,28 @@
+package io.github.nicolasraoul.rosette.data.db
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Entity(tableName = "bookmarks")
+data class Bookmark(
+    @PrimaryKey
+    val wikidataId: String,
+    val timestamp: Long
+)
+
+@Dao
+interface BookmarkDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(bookmark: Bookmark)
+
+    @Query("DELETE FROM bookmarks WHERE wikidataId = :wikidataId")
+    suspend fun delete(wikidataId: String)
+
+    @Query("SELECT * FROM bookmarks ORDER BY timestamp DESC")
+    fun getAll(): Flow<List<Bookmark>>
+}

--- a/app/src/main/java/io/github/nicolasraoul/rosette/data/db/BookmarkDatabase.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/data/db/BookmarkDatabase.kt
@@ -1,0 +1,29 @@
+package io.github.nicolasraoul.rosette.data.db
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [Bookmark::class], version = 1, exportSchema = false)
+abstract class BookmarkDatabase : RoomDatabase() {
+
+    abstract fun bookmarkDao(): BookmarkDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: BookmarkDatabase? = null
+
+        fun getDatabase(context: Context): BookmarkDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    BookmarkDatabase::class.java,
+                    "bookmark_database"
+                ).build()
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_star.xml
+++ b/app/src/main/res/drawable/ic_star.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_star_outline.xml
+++ b/app/src/main/res/drawable/ic_star_outline.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M22,9.24l-7.19,-0.62L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21 12,17.27 18.18,21l-1.63,-7.03L22,9.24zM12,15.4l-3.76,2.27 1,-4.28 -3.32,-2.88 4.38,-0.38L12,6.1l1.71,4.04 4.38,0.38 -3.32,2.88 1,4.28L12,15.4z"/>
+</vector>

--- a/app/src/main/res/layout/activity_bookmarks.xml
+++ b/app/src/main/res/layout/activity_bookmarks.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".BookmarksActivity">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar_bookmarks"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:elevation="4dp"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/bookmarks_recycler_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_bookmarks"
+        tools:listitem="@layout/bookmark_item" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/bookmark_item.xml
+++ b/app/src/main/res/layout/bookmark_item.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:background="?android:attr/selectableItemBackground">
+
+    <TextView
+        android:id="@+id/bookmark_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceListItem"
+        tools:text="Bookmark Title" />
+
+    <TextView
+        android:id="@+id/bookmark_timestamp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceListItemSecondary"
+        android:layout_marginTop="4dp"
+        tools:text="Saved on Jan 1, 2024"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/bookmark_item.xml
+++ b/app/src/main/res/layout/bookmark_item.xml
@@ -58,19 +58,4 @@
         app:layout_constraintTop_toBottomOf="@id/bookmark_title2"
         tools:text="Title 3" />
 
-    <TextView
-        android:id="@+id/bookmark_timestamp"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="8dp"
-        android:textAppearance="?attr/textAppearanceCaption"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/bookmark_image"
-        app:layout_constraintTop_toBottomOf="@id/bookmark_title3"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="1.0"
-        tools:text="Saved on Jan 1, 2024"/>
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/bookmark_item.xml
+++ b/app/src/main/res/layout/bookmark_item.xml
@@ -1,25 +1,76 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
     android:padding="16dp"
     android:background="?android:attr/selectableItemBackground">
 
+    <ImageView
+        android:id="@+id/bookmark_image"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:scaleType="centerCrop"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:src="@tools:sample/backgrounds/scenic" />
+
     <TextView
-        android:id="@+id/bookmark_title"
-        android:layout_width="match_parent"
+        android:id="@+id/bookmark_title1"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
         android:textAppearance="?attr/textAppearanceListItem"
-        tools:text="Bookmark Title" />
+        android:maxLines="1"
+        android:ellipsize="end"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/bookmark_image"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Title 1" />
+
+    <TextView
+        android:id="@+id/bookmark_title2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="4dp"
+        android:textAppearance="?attr/textAppearanceListItemSecondary"
+        android:maxLines="1"
+        android:ellipsize="end"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/bookmark_image"
+        app:layout_constraintTop_toBottomOf="@id/bookmark_title1"
+        tools:text="Title 2" />
+
+    <TextView
+        android:id="@+id/bookmark_title3"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="4dp"
+        android:textAppearance="?attr/textAppearanceListItemSecondary"
+        android:maxLines="1"
+        android:ellipsize="end"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/bookmark_image"
+        app:layout_constraintTop_toBottomOf="@id/bookmark_title2"
+        tools:text="Title 3" />
 
     <TextView
         android:id="@+id/bookmark_timestamp"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:textAppearance="?attr/textAppearanceListItemSecondary"
-        android:layout_marginTop="4dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:textAppearance="?attr/textAppearanceCaption"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/bookmark_image"
+        app:layout_constraintTop_toBottomOf="@id/bookmark_title3"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0"
         tools:text="Saved on Jan 1, 2024"/>
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -2,9 +2,17 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/action_bookmark"
+        android:title="@string/action_bookmark"
+        android:icon="@android:drawable/ic_menu_bookmark"
+        app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/action_bookmarks"
+        android:title="@string/action_bookmarks"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/action_settings"
         android:title="@string/language_settings"
         android:icon="@android:drawable/ic_menu_preferences"
-        android:showAsAction="always"
-        app:showAsAction="always" />
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -4,7 +4,7 @@
     <item
         android:id="@+id/action_bookmark"
         android:title="@string/action_bookmark"
-        android:icon="@android:drawable/ic_menu_bookmark"
+        android:icon="@android:drawable/ic_menu_star"
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/action_bookmarks"

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -4,7 +4,7 @@
     <item
         android:id="@+id/action_bookmark"
         android:title="@string/action_bookmark"
-        android:icon="@android:drawable/ic_menu_star"
+        android:icon="@drawable/ic_star"
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/action_bookmarks"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
     
     <!-- Language Settings -->
     <string name="language_settings">Language Settings</string>
+    <string name="action_bookmark">Bookmark</string>
+    <string name="action_bookmarks">Bookmarks</string>
     <string name="select_languages_title">Select Languages</string>
     <string name="select_languages_instruction">Select exactly 3 languages for your trilingual Wikipedia viewer:</string>
     <string name="selected_languages">Selected Languages:</string>


### PR DESCRIPTION
I've implemented the initial version of the bookmarking feature. You can now save, view, and load bookmarks.

Key changes include:
- **Database:** Integrated Room database to store bookmarks by their Wikidata ID and a timestamp.
- **UI:** Added a "Bookmark" button to the main toolbar and a new "Bookmarks" screen to list saved items.
- **ViewModel:** Implemented a ViewModel for the bookmarks screen to fetch data from the database and enrich it with titles from the Wikidata API.
- **Workflow:** You can save the currently viewed article set, see a list of your bookmarks, and load a bookmark to view the articles.

I haven't implemented the deletion of bookmarks yet, but I'll add that in a future commit.