### PR TITLE
feat: Display message for missing articles

### DIFF
--- a/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
@@ -340,12 +340,6 @@ class MainActivity : AppCompatActivity() {
 
     private fun getDisplayLanguageNames(): List<String> {
         return displayLanguages.map { lang ->
-            getDisplayLanguageName(lang)
-        }
-    }
-
-    private fun getDisplayLanguageName(lang: String): String {
-        return when (lang) {
             when (lang) {
                 "en" -> "English"
                 "fr" -> "French"

--- a/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
@@ -346,19 +346,21 @@ class MainActivity : AppCompatActivity() {
 
     private fun getDisplayLanguageName(lang: String): String {
         return when (lang) {
-            "en" -> "English"
-            "fr" -> "French"
-            "ja" -> "Japanese"
-            "es" -> "Spanish"
-            "de" -> "German"
-            "it" -> "Italian"
-            "pt" -> "Portuguese"
-            "ru" -> "Russian"
-            "zh" -> "Chinese"
-            "ar" -> "Arabic"
-            "hi" -> "Hindi"
-            "ko" -> "Korean"
-            else -> lang.uppercase()
+            when (lang) {
+                "en" -> "English"
+                "fr" -> "French"
+                "ja" -> "Japanese"
+                "es" -> "Spanish"
+                "de" -> "German"
+                "it" -> "Italian"
+                "pt" -> "Portuguese"
+                "ru" -> "Russian"
+                "zh" -> "Chinese"
+                "ar" -> "Arabic"
+                "hi" -> "Hindi"
+                "ko" -> "Korean"
+                else -> lang.uppercase()
+            }
         }
     }
 
@@ -630,8 +632,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun showMissingArticleMessage(webView: WebView?, lang: String) {
-        val languageName = getDisplayLanguageName(lang)
-        val message = "The $languageName Wikipedia is waiting for someone to write an article on that topic."
+        val message = "The $lang Wikipedia is waiting for someone to write an article on that topic."
         val htmlContent = """
             <html>
                 <body>

--- a/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
@@ -634,21 +634,6 @@ class MainActivity : AppCompatActivity() {
         val message = "The $languageName Wikipedia is waiting for someone to write an article on that topic."
         val htmlContent = """
             <html>
-                <head>
-                    <style>
-                        body {
-                            display: flex;
-                            justify-content: center;
-                            align-items: center;
-                            height: 100vh;
-                            margin: 0;
-                            font-family: sans-serif;
-                            text-align: center;
-                            padding: 20px;
-                            color: #888;
-                        }
-                    </style>
-                </head>
                 <body>
                     <p>$message</p>
                 </body>

--- a/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
@@ -340,21 +340,25 @@ class MainActivity : AppCompatActivity() {
 
     private fun getDisplayLanguageNames(): List<String> {
         return displayLanguages.map { lang ->
-            when (lang) {
-                "en" -> "English"
-                "fr" -> "French"
-                "ja" -> "Japanese"
-                "es" -> "Spanish"
-                "de" -> "German"
-                "it" -> "Italian"
-                "pt" -> "Portuguese"
-                "ru" -> "Russian"
-                "zh" -> "Chinese"
-                "ar" -> "Arabic"
-                "hi" -> "Hindi"
-                "ko" -> "Korean"
-                else -> lang.uppercase()
-            }
+            getDisplayLanguageName(lang)
+        }
+    }
+
+    private fun getDisplayLanguageName(lang: String): String {
+        return when (lang) {
+            "en" -> "English"
+            "fr" -> "French"
+            "ja" -> "Japanese"
+            "es" -> "Spanish"
+            "de" -> "German"
+            "it" -> "Italian"
+            "pt" -> "Portuguese"
+            "ru" -> "Russian"
+            "zh" -> "Chinese"
+            "ar" -> "Arabic"
+            "hi" -> "Hindi"
+            "ko" -> "Korean"
+            else -> lang.uppercase()
         }
     }
 
@@ -625,6 +629,34 @@ class MainActivity : AppCompatActivity() {
         return null
     }
 
+    private fun showMissingArticleMessage(webView: WebView?, lang: String) {
+        val languageName = getDisplayLanguageName(lang)
+        val message = "The $languageName Wikipedia is waiting for someone to write an article on that topic."
+        val htmlContent = """
+            <html>
+                <head>
+                    <style>
+                        body {
+                            display: flex;
+                            justify-content: center;
+                            align-items: center;
+                            height: 100vh;
+                            margin: 0;
+                            font-family: sans-serif;
+                            text-align: center;
+                            padding: 20px;
+                            color: #888;
+                        }
+                    </style>
+                </head>
+                <body>
+                    <p>$message</p>
+                </body>
+            </html>
+        """.trimIndent()
+        webView?.loadData(htmlContent, "text/html; charset=utf-8", "UTF-8")
+    }
+
     private fun performFullSearch(searchTerm: String, sitelinks: Map<String, String>? = null, wikidataId: String? = null) {
         Log.d(TAG, "performFullSearch: Starting a new search for '$searchTerm'. Wikidata ID: $wikidataId")
         this.currentWikidataId.value = wikidataId
@@ -650,8 +682,8 @@ class MainActivity : AppCompatActivity() {
                         webView?.loadUrl(getWikipediaPageUrl(lang, title))
                     } else {
                         pagesToLoad++
-                        Log.d(TAG, "performFullSearch (with sitelinks): No translation for $lang, loading search page.")
-                        webView?.loadUrl(getWikipediaBaseUrl(lang) + "/w/index.php?title=Special:Search&search=${searchTerm.replace(" ", "_")}")
+                        Log.d(TAG, "performFullSearch (with sitelinks): No translation for $lang, showing message.")
+                        showMissingArticleMessage(webView, lang)
                     }
                 }
             } else {
@@ -687,8 +719,8 @@ class MainActivity : AppCompatActivity() {
                         webView?.loadUrl(getWikipediaPageUrl(lang, title))
                     } else {
                         pagesToLoad++
-                        Log.d(TAG, "performFullSearch: No translation for $lang, loading search page.")
-                        webView?.loadUrl(getWikipediaBaseUrl(lang) + "/w/index.php?title=Special:Search&search=${finalTitleFromSource.replace(" ", "_")}")
+                        Log.d(TAG, "performFullSearch (no sitelinks): No translation for $lang, showing message.")
+                        showMissingArticleMessage(webView, lang)
                     }
                 }
             }


### PR DESCRIPTION
When a translation for an article does not exist in one of the selected languages, the app will now display a user-friendly message indicating that the article is waiting to be written.

This replaces the previous behavior of loading the Wikipedia search results page for the article's title, which could be confusing for users.

The implementation includes:
- A new helper function, `showMissingArticleMessage`, to generate and load a custom HTML message into the WebView.
- Refactoring of `performFullSearch` to use this new function in all cases where a translation is not found.
- A related refactoring to extract `getDisplayLanguageName` for better code reuse.