### PR TITLE
Fix WebView scaling issue on orientation change.

### DIFF
--- a/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
+++ b/app/src/main/java/io/github/nicolasraoul/rosette/MainActivity.kt
@@ -327,6 +327,11 @@ class MainActivity : AppCompatActivity() {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
+
+        // Trigger a resize event in the WebViews to force reflow
+        webViewMap.values.forEach { webView ->
+            webView.evaluateJavascript("window.dispatchEvent(new Event('resize'));", null)
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
When the device orientation changed, the content of the WebViews was not scaling correctly. This was because the app handles configuration changes manually but did not notify the WebViews of the change.

This commit fixes the issue by dispatching a "resize" event to each WebView in the `onConfigurationChanged` method. This triggers the web content to reflow and adapt to the new screen dimensions.