### PR TITLE
Fix: Improve visibility of three-dots menu buttons

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,16 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Base.Theme.TrilingualWiki" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:windowLightStatusBar">true</item>
+        <item name="textAppearanceSmallPopupMenu">@style/MyPopupMenuTextAppearanceSmall</item>
+        <item name="textAppearanceLargePopupMenu">@style/MyPopupMenuTextAppearanceLarge</item>
     </style>
 
     <style name="Theme.TrilingualWiki" parent="Base.Theme.TrilingualWiki" />
+
+    <style name="MyPopupMenuTextAppearanceSmall" parent="TextAppearance.Material3.BodyMedium">
+        <item name="android:textColor">@color/black</item>
+    </style>
+    <style name="MyPopupMenuTextAppearanceLarge" parent="TextAppearance.Material3.BodyLarge">
+        <item name="android:textColor">@color/black</item>
+    </style>
 </resources>


### PR DESCRIPTION
The buttons inside the three-dots menu had white text on a light grey background, making them barely visible.

This change introduces a custom style for the popup menu and sets the text color to black to ensure readability against the light background. This is applied to the main theme for both small and large popup menu text appearances.

This resolves issue #39.